### PR TITLE
Convert printf statements to log callbacks.

### DIFF
--- a/example.c
+++ b/example.c
@@ -6,6 +6,7 @@
  * published by Sam Hocevar. See the COPYING file for more details.
  */
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <assert.h>
 
@@ -50,6 +51,15 @@ static ssize_t op_read(struct ringfs_flash_partition *flash, int address, void *
     return size;
 }
 
+static void op_log(struct ringfs_flash_partition *flash, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    printf("[ringfs] %p ", flash);
+    vprintf(fmt, args);
+    va_end(args);
+}
+
 static struct ringfs_flash_partition flash = {
     .sector_size = FLASH_SECTOR_SIZE,
     .sector_offset = FLASH_PARTITION_OFFSET,
@@ -58,6 +68,7 @@ static struct ringfs_flash_partition flash = {
     .sector_erase = op_sector_erase,
     .program = op_program,
     .read = op_read,
+    .log = op_log
 };
 
 

--- a/ringfs.h
+++ b/ringfs.h
@@ -53,6 +53,13 @@ struct ringfs_flash_partition
      * @returns size on success, -1 on failure.
      */
     ssize_t (*read)(struct ringfs_flash_partition *flash, int address, void *data, size_t size);
+    /**
+     * Sends a log message to the application. May be unassigned.
+     * @param flash A pointer to this.
+     * @param fmt Format string.
+     * @param ... Arguments.
+     */
+    void (*log)(struct ringfs_flash_partition *flash, const char *fmt, ...);
 };
 
 /** @private */

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -8,6 +8,7 @@
 
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -85,6 +86,17 @@ static ssize_t op_read(struct ringfs_flash_partition *flash, int address, void *
     return size;
 }
 
+static void op_log(struct ringfs_flash_partition *flash, const char *fmt, ...)
+{
+    (void) flash;
+    va_list args;
+    va_start(args, fmt);
+    printf("[ringfs] ");
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+}
+
 /*
  * A really small filesystem: 3 slots per sector, 15 slots total.
  * Has the benefit of causing frequent wraparounds, potentially finding
@@ -98,6 +110,7 @@ static struct ringfs_flash_partition flash = {
     .sector_erase = op_sector_erase,
     .program = op_program,
     .read = op_read,
+    .log = op_log
 };
 
 static void fixture_flashsim_setup(void)


### PR DESCRIPTION
This works better on embedded targets where a printf destination might not necessarily be availble. It also allows the application to redirect logs to something other than stdout.
I'm not a huge fan of having at as a part of the partition struct. It would make more sense to have it a part of the `ringfs` struct, but the way things are initialized it's more natural to put it in the partition.

ringfs_dump still uses FILE as it's called by Python which has an issue with defining C callbacks with varadic arguments.