### PR TITLE
Add support for reading- and writing less than the object size.

### DIFF
--- a/ringfs.c
+++ b/ringfs.c
@@ -319,6 +319,15 @@ int ringfs_count_exact(struct ringfs *fs)
 
 int ringfs_append(struct ringfs *fs, const void *object)
 {
+    return ringfs_append_ex(fs, object, fs->object_size);
+}
+
+int ringfs_append_ex(struct ringfs *fs, const void *object, int size)
+{
+    if (size > fs->object_size || size < 0) {
+        return -1;
+    }
+
     uint32_t status;
 
     /*
@@ -360,7 +369,7 @@ int ringfs_append(struct ringfs *fs, const void *object)
     /* Write object. */
     fs->flash->program(fs->flash,
             _slot_address(fs, &fs->write) + sizeof(struct slot_header),
-            object, fs->object_size);
+            object, size);
 
     /* Commit write. */
     _slot_set_status(fs, &fs->write, SLOT_VALID);
@@ -373,6 +382,15 @@ int ringfs_append(struct ringfs *fs, const void *object)
 
 int ringfs_fetch(struct ringfs *fs, void *object)
 {
+    return ringfs_fetch_ex(fs, object, fs->object_size);
+}
+
+int ringfs_fetch_ex(struct ringfs *fs, void *object, int size)
+{
+    if (size > fs->object_size || size < 0) {
+        return -1;
+    }
+
     /* Advance forward in search of a valid slot. */
     while (!_loc_equal(&fs->cursor, &fs->write)) {
         uint32_t status;
@@ -382,7 +400,7 @@ int ringfs_fetch(struct ringfs *fs, void *object)
         if (status == SLOT_VALID) {
             fs->flash->read(fs->flash,
                     _slot_address(fs, &fs->cursor) + sizeof(struct slot_header),
-                    object, fs->object_size);
+                    object, size);
             _loc_advance_slot(fs, &fs->cursor);
             return 0;
         }

--- a/ringfs.h
+++ b/ringfs.h
@@ -138,6 +138,7 @@ int ringfs_count_exact(struct ringfs *fs);
 
 /**
  * Append an object at the end of the ring. Deletes oldest objects as needed.
+ * This assumes that \p object has the same size as specified in ringfs_init().
  *
  * @param fs Initialized RingFS instance.
  * @param object Object to be stored.
@@ -146,13 +147,38 @@ int ringfs_count_exact(struct ringfs *fs);
 int ringfs_append(struct ringfs *fs, const void *object);
 
 /**
+ * Append an object at the end of the ring. Deletes oldest objects as needed.
+ * \p size must be positive and less than or equal to the size specified in
+ * ringfs_init().
+ *
+ * @param fs Initialized RingFS instance.
+ * @param object Object to be stored.
+ * @param size Size of the object in bytes.
+ * @returns Zero on success, -1 on failure.
+ */
+int ringfs_append_ex(struct ringfs *fs, const void *object, int size);
+
+/**
  * Fetch next object from the ring, oldest-first. Advances read cursor.
+ * This assumes that \p object has the same size as specified in ringfs_init().
  *
  * @param fs Initialized RingFS instance.
  * @param object Buffer to store retrieved object.
  * @returns Zero on success, -1 on failure.
  */
 int ringfs_fetch(struct ringfs *fs, void *object);
+
+/**
+ * Fetch next object from the ring, oldest-first. Advances read cursor.
+ * \p size must be positive and less than or equal to the size specified in
+ * ringfs_init().
+ *
+ * @param fs Initialized RingFS instance.
+ * @param object Buffer to store retrieved object.
+ * @param size Size of the object in bytes.
+ * @returns Zero on success, -1 on failure.
+ */
+int ringfs_fetch_ex(struct ringfs *fs, void *object, int size);
 
 /**
  * Discard all fetched objects up to the read cursor.

--- a/tests/pyringfs.py
+++ b/tests/pyringfs.py
@@ -54,7 +54,9 @@ class libringfs(GenericLibrary):
         ['ringfs_count_estimate', [POINTER(StructRingFS)], c_int],
         ['ringfs_count_exact', [POINTER(StructRingFS)], c_int],
         ['ringfs_append', [POINTER(StructRingFS), c_void_p], c_int],
+        ['ringfs_append_ex', [POINTER(StructRingFS), c_void_p, c_int], c_int],
         ['ringfs_fetch', [POINTER(StructRingFS), c_void_p], c_int],
+        ['ringfs_fetch_ex', [POINTER(StructRingFS), c_void_p], c_int],
         ['ringfs_discard', [POINTER(StructRingFS)], c_int],
         ['ringfs_rewind', [POINTER(StructRingFS)], c_int],
         ['ringfs_dump', [c_void_p, POINTER(StructRingFS)], None],
@@ -111,9 +113,17 @@ class RingFS(object):
     def append(self, obj):
         self.libringfs.ringfs_append(byref(self.ringfs), obj)
 
+    def append_ex(self, obj, size):
+        self.libringfs.ringfs_append_ex(byref(self.ringfs), obj, size)
+
     def fetch(self):
         obj = create_string_buffer(self.object_size)
         self.libringfs.ringfs_append(byref(self.ringfs), obj)
+        return obj.raw
+
+    def fetch_ex(self, size):
+        obj = create_string_buffer(size)
+        self.libringfs.ringfs_fetch_ex(byref(self.ringfs), obj, size)
         return obj.raw
 
     def discard(self):


### PR DESCRIPTION
This allows you to read- and write structs as uint8_t buffers without having to go through an intermediate buffer or a union.

New functions have been introduced to accept a size variable:
- ringfs_append_ex
- ringfs_fetch_ex

The original functions were changed to invoke the _ex versions with the object size as the read/write size. This was done to maintain backwards compatibility.

This closes #6 