### PR TITLE
Make discarding old data when flash is full optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ semantics:
 
 See ``example.c`` if this sounds complicated.
 
+### Write behavior when full
+
+Ringfs requires at least one sector free when it appends data as it moves the
+read- and cursor heads to the next sector when the current one is full. By
+default it will erase the next sector if needed. This behavior can be prevented
+by setting `ringfs.reject_write_when_full` to `1`. When enabled `ringfs_append`
+will return `RINGFS_FULL` and the data will be rejected.
+
+Due to this the filesystem can at most hold `size - sector_size` of data.
+
 ## Documentation
 
 See Doxygen-generated documentation at http://cloudyourcar.github.io/ringfs/.
@@ -51,7 +61,7 @@ object sizes some day.
 ## License
 
 > Copyright © 2014 Kosma Moczek \<kosma@cloudyourcar.com\>
-> 
+>
 > This program is free software. It comes without any warranty, to the extent
 > permitted by applicable law. You can redistribute it and/or modify it under
 > the terms of the Do What The Fuck You Want To Public License, Version 2, as

--- a/ringfs.h
+++ b/ringfs.h
@@ -22,6 +22,10 @@ extern "C" {
 #include <stdio.h>
 #include <unistd.h>
 
+#define RINGFS_OK        0
+#define RINGFS_ERROR    -1
+#define RINGFS_FULL     -2
+
 /**
  * Flash memory+parition descriptor.
  */
@@ -84,6 +88,13 @@ struct ringfs {
     struct ringfs_loc read;
     struct ringfs_loc write;
     struct ringfs_loc cursor;
+
+    /**
+     * Write behavior when fs is full.
+     * 0 - discard old data (default)
+     * 1 - reject new data
+     */
+    int reject_write_when_full;
 };
 
 /**
@@ -149,7 +160,9 @@ int ringfs_count_exact(struct ringfs *fs);
  *
  * @param fs Initialized RingFS instance.
  * @param object Object to be stored.
- * @returns Zero on success, -1 on failure.
+ * @retval RINGFS_OK on success
+ * @retval RINGFS_ERROR if the size is invalid or the write fails
+ * @retval RINGFS_FULL if the ring is full and reject_write_when_full is set
  */
 int ringfs_append(struct ringfs *fs, const void *object);
 
@@ -161,7 +174,9 @@ int ringfs_append(struct ringfs *fs, const void *object);
  * @param fs Initialized RingFS instance.
  * @param object Object to be stored.
  * @param size Size of the object in bytes.
- * @returns Zero on success, -1 on failure.
+ * @retval RINGFS_OK on success
+ * @retval RINGFS_ERROR if the size is invalid or the write fails
+ * @retval RINGFS_FULL if the ring is full and reject_write_when_full is set
  */
 int ringfs_append_ex(struct ringfs *fs, const void *object, int size);
 


### PR DESCRIPTION
The default (memset the ringfs struct to 0) is to retain the old behavior of discarding old data on flash if it gets full. Setting ringfs.reject_write_when_full to 1 will now return RINGFS_FULL if the next sector already contains data.

Migrate ringfs_append and ringfs_append_ex to use error codes rather than just returning -1 on everything.