### PR TITLE
[bugfix][ringfs_scan]: Fix problems with the scanning process

### DIFF
--- a/ringfs.c
+++ b/ringfs.c
@@ -215,6 +215,7 @@ int ringfs_scan(struct ringfs *fs)
         if (header.status == SECTOR_ERASING || header.status == SECTOR_ERASED) {
             _sector_free(fs, sector, header.status);
             header.status = SECTOR_FREE;
+            header.version = fs->version;
         }
 
         /* Detect corrupted sectors. */


### PR DESCRIPTION
When free rebuilding partitions during the partition scanning process, the header information needs to be updated Otherwise, errors may occur during version checking in next line.

Pulled from https://github.com/cloudyourcar/ringfs/pull/12