### PR TITLE
Move reject_write_when_full to a config and assign it at init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ See ``example.c`` if this sounds complicated.
 Ringfs requires at least one sector free when it appends data as it moves the
 read- and cursor heads to the next sector when the current one is full. By
 default it will erase the next sector if needed. This behavior can be prevented
-by setting `ringfs.reject_write_when_full` to `1`. When enabled `ringfs_append`
-will return `RINGFS_FULL` and the data will be rejected.
+by setting `ringfs.config.reject_write_when_full` to `1`. When enabled
+`ringfs_append` will return `RINGFS_FULL` and the data will be rejected.
 
 Due to this the filesystem can at most hold `size - sector_size` of data.
 

--- a/ringfs.c
+++ b/ringfs.c
@@ -154,6 +154,7 @@ void ringfs_init(struct ringfs *fs, struct ringfs_flash_partition *flash, uint32
     fs->flash = flash;
     fs->version = version;
     fs->object_size = object_size;
+    fs->config.reject_write_when_full = false;
 
     /* Precalculate commonly used values. */
     fs->slots_per_sector = (fs->flash->sector_size - sizeof(struct sector_header)) /
@@ -351,7 +352,7 @@ int ringfs_append_ex(struct ringfs *fs, const void *object, int size)
      * Next sector contains data. Depending on the configured write behavior we
      * need to either reject the write request or delete old data
      */
-    if (status == SECTOR_IN_USE && fs->reject_write_when_full)
+    if (status == SECTOR_IN_USE && fs->config.reject_write_when_full)
         return RINGFS_FULL;
 
     if (status != SECTOR_FREE) {

--- a/ringfs.h
+++ b/ringfs.h
@@ -73,6 +73,22 @@ struct ringfs_loc {
 };
 
 /**
+ * User controlled configuration.
+ *
+ * Used by the application to configure RingFS behavior.
+ * The default values are set in ringfs_init() and can be changed
+ * after initialization.
+ */
+struct ringfs_config {
+    /**
+     * Write behavior when fs is full.
+     * 0 - discard old data (default)
+     * 1 - reject new data
+     */
+    int reject_write_when_full;
+};
+
+/**
  * RingFS instance. Should be initialized with ringfs_init() befure use.
  * Structure fields should not be accessed directly.
  * */
@@ -89,12 +105,8 @@ struct ringfs {
     struct ringfs_loc write;
     struct ringfs_loc cursor;
 
-    /**
-     * Write behavior when fs is full.
-     * 0 - discard old data (default)
-     * 1 - reject new data
-     */
-    int reject_write_when_full;
+    /* User controlled configuration */
+    struct ringfs_config config;
 };
 
 /**

--- a/tests/pyringfs.py
+++ b/tests/pyringfs.py
@@ -31,6 +31,11 @@ class StructRingFSLoc(Structure):
         ('slot', c_int),
     ]
 
+class StructRingFSConfig(Structure):
+    _fields_ = [
+        ('reject_write_when_full', c_int)
+    ]
+
 class StructRingFS(Structure):
     _fields_ = [
         ('flash', POINTER(StructRingFSFlashPartition)),
@@ -41,6 +46,7 @@ class StructRingFS(Structure):
         ('read', StructRingFSLoc),
         ('write', StructRingFSLoc),
         ('cursor', StructRingFSLoc),
+        ('config', StructRingFSConfig)
     ]
 
 


### PR DESCRIPTION
It was previously assigned whatever was available in the stack which caused tests to fail.